### PR TITLE
Speed up import time

### DIFF
--- a/src/dbImportStream.js
+++ b/src/dbImportStream.js
@@ -16,7 +16,13 @@ function streamFactory(db){
             city TEXT NOT NULL,
             lon REAL NOT NULL,
             lat REAL NOT NULL
-        );`);
+        );
+        PRAGMA JOURNAL_MODE=OFF;
+        PRAGMA SYNCHRONOUS=OFF;
+        PRAGMA LOCKING_MODE=EXCLUSIVE;
+        PRAGMA PAGE_SIZE=4096;
+        PRAGMA CACHE_SIZE=100;
+        PRAGMA TEMP_STORE=MEMORY;`);
 
     // prepare insert statement
     const stmt = db.prepare(`INSERT INTO lastline (postcode,city,lon,lat) VALUES (?,?,?,?)`);

--- a/src/dbImportStream.js
+++ b/src/dbImportStream.js
@@ -17,7 +17,7 @@ function streamFactory(db){
             lon REAL NOT NULL,
             lat REAL NOT NULL
         );
-        PRAGMA JOURNAL_MODE=OFF;
+        PRAGMA JOURNAL_MODE=MEMORY;
         PRAGMA SYNCHRONOUS=OFF;
         PRAGMA LOCKING_MODE=EXCLUSIVE;
         PRAGMA PAGE_SIZE=4096;


### PR DESCRIPTION
:wave: I did some awesome work for the Pelias project and would love for everyone to have a look at it and provide feedback.

---
#### Here's the reason for this change :rocket:
<!-- good place to use the magic github words that connect issues with PRs, like 
  - Fixes pelias/pelias#0000
  - Closes pelias/pelias#0000
  - Connected to pelias/pelias#0000
you can also just use good ol' words to explain what this does -->

The import is very very slow, this is caused by the [synchronous option](https://www.sqlite.org/pragma.html#pragma_synchronous) from SQLite. I don't think that is important to enable it... The import took +3hours (stopped before the end) for [Uruguay](http://download.geofabrik.de/south-america/uruguay.html) and 40s with this PR.

---
#### Here's what actually got changed :clap:
<!-- try listing some of the things in a nifty checklist
- [x] :cat:
- [ ] :dog:
- [x] :rabbit:
-->

I disabled synchronous and added some other options used by [whosonfirst/go-whosonfirst-sqlite](https://github.com/whosonfirst/go-whosonfirst-sqlite/blob/a3e06adf934118b5f5d930b714586f9043591317/database/database.go#L72-L78), [pelias/wof](https://github.com/pelias/wof/blob/3a5df652b477417f51d4486b0f53814e2c268f42/sqlite/pragma.js#L3-L11) and [Joxit/wof-cli](https://github.com/Joxit/wof-cli/blob/c3c570c0999377ec2e56bd1879a64f15f5ac1708/src/sqlite/statements.rs#L142-L147).
