### PR TITLE
Make WOF placetypes passed to the placeholder /parser/search endpoint configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,11 +153,14 @@ The following variables are available to overrite default values:
 
 | env var | default value | description |
 |---|---|---|
-| DB_FILENAME | osm.postcodes.db | Path to the database file which is written to disk |
-| PLACEHOLDER_HOST | localhost | Host name of a running placeholder service |
-| PLACEHOLDER_PORT | 3000 | Port number of a running placeholder service |
-| PLACEHOLDER_QPS | 30 | A rate-limit for querying the placeholder service (max per second) |
-| MAX_DISTANCE_KM | 200 | The maximum distance a postcode coordinate can be from the locality (in km) |
+| `DB_FILENAME` | `osm.postcodes.db` | Path to the database file which is written to disk |
+| `PLACEHOLDER_HOST` | `localhost` | Host name of a running placeholder service |
+| `PLACEHOLDER_PORT` | `3000` | Port number of a running placeholder service |
+| `PLACEHOLDER_QPS` | `30` | A rate-limit for querying the placeholder service (max per second) |
+| `PLACEHOLDER_PLACETYPES` | `locality,borough` | Comma separated list of Who's On First [placetypes](https://github.com/whosonfirst/whosonfirst-placetypes) to be used when querying the placeholder service |
+| `MAX_DISTANCE_KM` | 200 | The maximum distance a postcode coordinate can be from the locality (in km) |
+
+*Important Note:* currently the place types that can be used via the `PLACEHOLDER_PLACETYPES` environment variable as used _as is_ and are not subject to validation.
 
 ## Optional post-processing
 

--- a/src/placeholderLookup.js
+++ b/src/placeholderLookup.js
@@ -3,9 +3,11 @@ const keepaliveAgent = require('./httpAgent')();
 const selectLocality = require('./selectLocality');
 
 const PLACEHOLDER_DEFAULT_QPS = 30;
+const PLACEHOLDER_DEFAULT_PLACETYPES = 'locality,borough';
 const PLACEHOLDER_HOST = process.env.PLACEHOLDER_HOST || 'localhost';
 const PLACEHOLDER_PORT = process.env.PLACEHOLDER_PORT || '3000';
 const PLACEHOLDER_QPS = parseInt(process.env.PLACEHOLDER_QPS, 10);
+const PLACEHOLDER_PLACETYPES = process.env.PLACEHOLDER_PLACETYPES || PLACEHOLDER_DEFAULT_PLACETYPES;
 
 const PLACEHOLDER_HTTP_URL = `http://${PLACEHOLDER_HOST}:${PLACEHOLDER_PORT}/parser/search`;
 const PLACEHOLDER_QPS_LIMIT = PLACEHOLDER_QPS || PLACEHOLDER_DEFAULT_QPS;
@@ -18,7 +20,7 @@ function placeholder(row){
          .query({
             text: row.city,
             lang: 'eng',
-            placetype: 'locality,borough'
+            placetype: PLACEHOLDER_PLACETYPES
          })
          .end((err, res) => {
             var locality = selectLocality(row, err, res);


### PR DESCRIPTION
Related to and in the same spirit as #10 from @missinglink, this PR adds support to override the default `locality` and `borough` placetypes used when querying the `/parser/search` endpoint on the placeholder service with an optional list of WOF placetypes via the `PLACEHOLDER_PLACETYPES` environment variable.
